### PR TITLE
Update WPILib to 2026.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id "java"
-	id "edu.wpi.first.GradleRIO" version "2026.1.1"
+	id "edu.wpi.first.GradleRIO" version "2026.2.1"
 	id "com.peterabeles.gversion" version "1.10"
 	id "com.diffplug.spotless" version "7.0.2"
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -74,6 +74,6 @@ public final class Constants {
 		/**
 		 * AprilTag Field Layout for the current game.
 		 */
-		public static final AprilTagFieldLayout FIELD_LAYOUT = AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeAndyMark);
+		public static final AprilTagFieldLayout FIELD_LAYOUT = AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltAndymark);
 	}
 }


### PR DESCRIPTION
Updates WPILib to version 2026.2.1 and updates the AprilTagFieldLayout to this year's field since the new version added that.