### PR TITLE
Add a spotless task to VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,10 @@
 		{
 			"label": "Format with Spotless",
 			"type": "shell",
-			"command": "./gradlew spotlessApply",
+			"command": "./gradlew",
+			"args": [
+				"spotlessApply"
+			],
 			"presentation": {
 				"reveal": "always",
 				"panel": "shared"


### PR DESCRIPTION
Adds a task to VSCode that runs the Spotless formatter. This can be run by opening the command palette (`Ctrl/Cmd + Shift + P`), typing `Run Task`, and then selecting `Format with Spotless`.