### PR TITLE
Shooter target check override

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -367,7 +367,7 @@ public final class Constants {
 		/**
 		 * The time to wait before overriding subsystems and just shooting anyway.
 		 */
-		public static final Time SHOOTING_WAITING_TIMEOUT = Seconds.of(2.0);
+		public static final Time SHOOTING_WAITING_TIMEOUT = Seconds.of(1.0);
 	}
 
 	/**

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -363,6 +363,11 @@ public final class Constants {
 		 * the transform from the center of the pivot on top of the shooter base plate to the center of the hood pivot axis in meters
 		 */
 		public static final Transform3d TURRET_BASE_TO_HOOD_PIVOT = new Transform3d(0.126746, 0, 0.0635, new Rotation3d());
+
+		/**
+		 * The time to wait before overriding subsystems and just shooting anyway.
+		 */
+		public static final Time SHOOTING_WAITING_TIMEOUT = Seconds.of(2.0);
 	}
 
 	/**

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -101,8 +101,7 @@ public class Shooter extends SubsystemBase {
 	}
 
 	public boolean isAtTarget() {
-		return true;
-		// return MathUtil.isNear(requestedSpeed.in(RotationsPerSecond), leaderMotor.getVelocity().getValueAsDouble(), ShooterConstants.TOLERANCE.in(RotationsPerSecond));
+		return MathUtil.isNear(requestedSpeed.in(RotationsPerSecond), leaderMotor.getVelocity().getValueAsDouble(), ShooterConstants.TOLERANCE.in(RotationsPerSecond));
 	}
 
 	public void startFlywheel(AngularVelocity speed) {

--- a/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
+++ b/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
@@ -532,7 +532,7 @@ public class ShooterSuperstructure {
 	 *         Are all the shooter subsystems at their targets?
 	 */
 	public boolean subsystemsAtTargets() {
-		return true; // flywheel.isAtTarget() && hood.isAtPosition() && turret.isAtTarget() && hopperUptake.isUptakeAtTarget();
+		return flywheel.isAtTarget() && hood.isAtPosition() && turret.isAtTarget() && hopperUptake.isUptakeAtTarget();
 	}
 
 	/**

--- a/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
+++ b/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
@@ -247,7 +247,7 @@ public class ShooterSuperstructure {
 
 		stateMachineConfig.configure(ShooterState.SHOOTING_WAITING)
 				.substateOf(ShooterState.SHOOTING_STAGE_3_SHOOTING)
-				.permit(ShooterTrigger.START_SHOOTING, ShooterState.SHOOTING_RUNNING)
+				.permit(ShooterTrigger.READY_TO_SHOOT, ShooterState.SHOOTING_RUNNING)
 				// Restart the shooting waiting timer when we start waiting
 				.onEntry(shootingWaitingTimeout::restart)
 				// And stop it when we stop
@@ -381,7 +381,7 @@ public class ShooterSuperstructure {
 
 				if (subsystemsAtTargets() || (shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT) && DriverStation.isAutonomous())) {
 					// Ready to start shooting again, so let's do that
-					stateMachine.fire(ShooterTrigger.START_SHOOTING);
+					stateMachine.fire(ShooterTrigger.READY_TO_SHOOT);
 					break;
 				}
 

--- a/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
+++ b/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
@@ -271,6 +271,7 @@ public class ShooterSuperstructure {
 		SmartDashboard.putData(SuperstructureConstants.SHOOTER_SUPERSTRUCTURE_TABLE_NAME + "/Home", homeCommand());
 		SmartDashboard.putData(SuperstructureConstants.SHOOTER_SUPERSTRUCTURE_TABLE_NAME + "/Start Manual Control", startManualControlCommand());
 		SmartDashboard.putData(SuperstructureConstants.SHOOTER_SUPERSTRUCTURE_TABLE_NAME + "/Start Shooting", startShootingCommand());
+		SmartDashboard.putData(SuperstructureConstants.SHOOTER_SUPERSTRUCTURE_TABLE_NAME + "/Skip Waiting", skipWaitingCommand());
 	}
 
 	/**
@@ -467,6 +468,16 @@ public class ShooterSuperstructure {
 	public Command startShootingWhenReadyCommand() {
 		return Commands.waitUntil(readyToShootTrigger())
 				.andThen(startShootingCommand());
+	}
+
+	/**
+	 * Command that skips the regular checks of if we're at our setpoint and forces the state machineto continue.
+	 *
+	 * @return
+	 *         Command to run.
+	 */
+	public Command skipWaitingCommand() {
+		return Commands.runOnce(() -> stateMachine.fire(ShooterTrigger.READY_TO_SHOOT));
 	}
 
 	/**

--- a/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
+++ b/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
@@ -9,7 +9,6 @@ import com.github.oxo42.stateless4j.StateMachineConfig;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -152,8 +151,6 @@ public class ShooterSuperstructure {
 	private final Timer shooterTimeout = new Timer();
 	/**
 	 * Timer used to override subsystem checks if it takes too long for subsystems to ready. Once this timer elapses the {@link SuperstructureConstants#SHOOTING_WAITING_TIMEOUT}, the superstructure will continue on from the waiting state and just shoot anyway.
-	 * <p>
-	 * This only takes effect in autonomous.
 	 */
 	private final Timer shootingWaitingTimeout = new Timer();
 
@@ -316,7 +313,7 @@ public class ShooterSuperstructure {
 				}
 
 				// Once we reach the target, start to track
-				if (subsystemsAtTargets() || (shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT) && DriverStation.isAutonomous())) {
+				if (subsystemsAtTargets() || shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT)) {
 					stateMachine.fire(ShooterTrigger.READY_TO_SHOOT);
 					break;
 				}
@@ -380,7 +377,7 @@ public class ShooterSuperstructure {
 					stateMachine.fire(ShooterTrigger.HOME);
 				}
 
-				if (subsystemsAtTargets() || (shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT) && DriverStation.isAutonomous())) {
+				if (subsystemsAtTargets() || shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT)) {
 					// Ready to start shooting again, so let's do that
 					stateMachine.fire(ShooterTrigger.READY_TO_SHOOT);
 					break;

--- a/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
+++ b/src/main/java/frc/robot/superstructure/ShooterSuperstructure.java
@@ -9,6 +9,7 @@ import com.github.oxo42.stateless4j.StateMachineConfig;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -149,6 +150,12 @@ public class ShooterSuperstructure {
 	 * Timer used to time the stopping of the shooter.
 	 */
 	private final Timer shooterTimeout = new Timer();
+	/**
+	 * Timer used to override subsystem checks if it takes too long for subsystems to ready. Once this timer elapses the {@link SuperstructureConstants#SHOOTING_WAITING_TIMEOUT}, the superstructure will continue on from the waiting state and just shoot anyway.
+	 * <p>
+	 * This only takes effect in autonomous.
+	 */
+	private final Timer shootingWaitingTimeout = new Timer();
 
 	/**
 	 * The current source to poll for shooting values.
@@ -205,7 +212,14 @@ public class ShooterSuperstructure {
 
 		stateMachineConfig.configure(ShooterState.SHOOTING_STAGE_1_INITIALIZING)
 				.substateOf(ShooterState.SHOOTING)
-				.permit(ShooterTrigger.READY_TO_SHOOT, ShooterState.SHOOTING_STAGE_2_READY_TO_SHOOT);
+				.permit(ShooterTrigger.READY_TO_SHOOT, ShooterState.SHOOTING_STAGE_2_READY_TO_SHOOT)
+				// Restart the shooting waiting timer when we start waiting
+				.onEntry(shootingWaitingTimeout::restart)
+				// And stop it when we stop
+				.onExit(() -> {
+					shootingWaitingTimeout.stop();
+					shootingWaitingTimeout.reset();
+				});
 
 		stateMachineConfig.configure(ShooterState.SHOOTING_STAGE_2_READY_TO_SHOOT)
 				.substateOf(ShooterState.SHOOTING)
@@ -233,7 +247,14 @@ public class ShooterSuperstructure {
 
 		stateMachineConfig.configure(ShooterState.SHOOTING_WAITING)
 				.substateOf(ShooterState.SHOOTING_STAGE_3_SHOOTING)
-				.permit(ShooterTrigger.START_SHOOTING, ShooterState.SHOOTING_RUNNING);
+				.permit(ShooterTrigger.START_SHOOTING, ShooterState.SHOOTING_RUNNING)
+				// Restart the shooting waiting timer when we start waiting
+				.onEntry(shootingWaitingTimeout::restart)
+				// And stop it when we stop
+				.onExit(() -> {
+					shootingWaitingTimeout.stop();
+					shootingWaitingTimeout.reset();
+				});
 
 		stateMachineConfig.configure(ShooterState.SHOOTING_PAUSED)
 				.substateOf(ShooterState.SHOOTING_STAGE_3_SHOOTING)
@@ -294,7 +315,7 @@ public class ShooterSuperstructure {
 				}
 
 				// Once we reach the target, start to track
-				if (subsystemsAtTargets()) {
+				if (subsystemsAtTargets() || (shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT) && DriverStation.isAutonomous())) {
 					stateMachine.fire(ShooterTrigger.READY_TO_SHOOT);
 					break;
 				}
@@ -358,7 +379,7 @@ public class ShooterSuperstructure {
 					stateMachine.fire(ShooterTrigger.HOME);
 				}
 
-				if (subsystemsAtTargets()) {
+				if (subsystemsAtTargets() || (shootingWaitingTimeout.hasElapsed(SuperstructureConstants.SHOOTING_WAITING_TIMEOUT) && DriverStation.isAutonomous())) {
 					// Ready to start shooting again, so let's do that
 					stateMachine.fire(ShooterTrigger.START_SHOOTING);
 					break;


### PR DESCRIPTION
Adds a proper override for shooter target checks. This uses a configurable timeout during autonomous, and can be mapped to a button for teleop.