### PR TITLE
Add a current spike check to Intake agitate

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -245,6 +245,7 @@ public final class Constants {
 		public static final double AGITATE_RAISED_DISTANCE = SHOULDER_MINIMUM_DISTANCE;
 		public static final double AGITATE_TOLERANCE = 0.5;
 		public static final Current AGITATE_CURRENT_SPIKE_THRESHOLD = Amps.of(10.0);
+		public static final Time AGITATE_CURRENT_SPIKE_DELAY = Seconds.of(0.2);
 
 		// PID vals for moving the intake in
 		public static final double INTAKE_KG_0 = 0.1;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -244,6 +244,7 @@ public final class Constants {
 		public static final double AGITATE_LOWERED_DISTANCE = SHOULDER_MAXIMUM_DISTANCE;
 		public static final double AGITATE_RAISED_DISTANCE = SHOULDER_MINIMUM_DISTANCE;
 		public static final double AGITATE_TOLERANCE = 0.5;
+		public static final Current AGITATE_CURRENT_SPIKE_THRESHOLD = Amps.of(10.0);
 
 		// PID vals for moving the intake in
 		public static final double INTAKE_KG_0 = 0.1;

--- a/src/main/java/frc/robot/subsystems/intake/IntakeShoulder.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeShoulder.java
@@ -403,6 +403,16 @@ public class IntakeShoulder extends SubsystemBase {
 	}
 
 	/**
+	 * Checks if the current draw of the motor is above the {@link IntakeConstants#AGITATE_CURRENT_SPIKE_THRESHOLD}.
+	 *
+	 * @return
+	 *         Is the current draw over the threshold?
+	 */
+	private boolean getAgitateCurrentSpike() {
+		return motor.getTorqueCurrent().getValue().compareTo(IntakeConstants.AGITATE_CURRENT_SPIKE_THRESHOLD) > 0.0;
+	}
+
+	/**
 	 * Method which moves arm to a raised position when in lowered position and vice
 	 * versa. This is intended to be called through a continuous RunCommand
 	 * triggered by a held button. Does not have an end state by default, this must
@@ -410,7 +420,7 @@ public class IntakeShoulder extends SubsystemBase {
 	 */
 
 	private void agitate() {
-		if (getIsRaised()) {
+		if (getIsRaised() || getAgitateCurrentSpike()) {
 			lowerAgitate();
 		} else if (getIsLowered()) {
 			raiseAgitate();

--- a/src/main/java/frc/robot/subsystems/intake/IntakeShoulder.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeShoulder.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.intake;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -31,6 +32,11 @@ public class IntakeShoulder extends SubsystemBase {
 	private final CANcoder intakeEncoder = new CANcoder(IntakeConstants.SHOULDER_ENCODER_CAN_ID, Constants.CANIVORE_BUS);
 
 	private double setPointMeters;
+
+	/**
+	 * Timer that delays when the current spike check for agitate is done. This allows us to make sure the initial starting current of the motor doesn't trip the check.
+	 */
+	private Timer agitateCurrentSpikeDelay = new Timer();
 
 	/**
 	 * Constructor for motor which raises and lowers intakes with associated
@@ -378,6 +384,8 @@ public class IntakeShoulder extends SubsystemBase {
 	 */
 	private void raiseAgitate() {
 		setPositionInSlow(IntakeConstants.AGITATE_RAISED_DISTANCE);
+
+		agitateCurrentSpikeDelay.restart();
 	}
 
 	public boolean getHasReachedTarget(double distance, double tolerance) {
@@ -420,7 +428,7 @@ public class IntakeShoulder extends SubsystemBase {
 	 */
 
 	private void agitate() {
-		if (getIsRaised() || getAgitateCurrentSpike()) {
+		if (getIsRaised() || (getAgitateCurrentSpike() && agitateCurrentSpikeDelay.hasElapsed(IntakeConstants.AGITATE_CURRENT_SPIKE_DELAY))) {
 			lowerAgitate();
 		} else if (getIsLowered()) {
 			raiseAgitate();


### PR DESCRIPTION
Adds a current spike check that will check if there's a current spike while raising the intake during agitate and override the target check (we are likely stuck on a ball in this case).